### PR TITLE
LPS-85536 Replace isSelectionEmpty calls with calls to _isEmptySelect…

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -104,10 +104,20 @@
 				return imgEl;
 			},
 
+			_isEmptySelection: function(editor) {
+				var selection = editor.getSelection();
+
+				var ranges = selection.getRanges();
+
+				var collapsedRange = ranges.length === 1 && ranges[0].collapsed;
+
+				return selection.getType() === CKEDITOR.SELECTION_NONE || collapsedRange;
+			},
+
 			_onSelectedImageChange: function(editor, imageSrc, selectedItem) {
 				var el;
 				var instance = this;
-				var isSelectionEmpty = editor.isSelectionEmpty();
+				var isSelectionEmpty = instance._isEmptySelection(editor);
 				var fileEntryAttributeName = editor.config.adaptiveMediaFileEntryAttributeName;
 
 				if (selectedItem.returnType === STR_ADAPTIVE_MEDIA_URL_RETURN_TYPE) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -359,6 +359,16 @@
 				return itemSrc;
 			},
 
+			_isEmptySelection: function(editor) {
+				var selection = editor.getSelection();
+
+				var ranges = selection.getRanges();
+
+				var collapsedRange = ranges.length === 1 && ranges[0].collapsed;
+
+				return selection.getType() === CKEDITOR.SELECTION_NONE || collapsedRange;
+			},
+
 			_onSelectedAudioChange: function(editor, callback, event) {
 				var instance = this;
 
@@ -386,7 +396,7 @@
 				if (selectedItem) {
 					var eventName = editor.name + 'selectItem';
 					var imageSrc = instance._getItemSrc(editor, selectedItem);
-					var isSelectionEmpty = editor.isSelectionEmpty();
+					var isSelectionEmpty = instance._isEmptySelection(editor);
 
 					Liferay.Util.getWindow(eventName).onceAfter(
 						'destroy',


### PR DESCRIPTION
…ion as seen in the autocomplete.js plugin since isSelectionEmpty is not a function in CKEditor

Please let me know what you think about my proposed solution for https://issues.liferay.com/browse/LPS-85536 and forward it to your normal reviewer if it looks good to you. The reason why I ended up going with  duplicating the functionality is that it's more modular and future-proofed to any potential other uses of this function down the road.